### PR TITLE
Normalize data structure across stores

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,11 +55,11 @@ class Keyv extends EventEmitter {
 				if (data === undefined) {
 					return undefined;
 				}
-				if (!store.ttlSupport && typeof data.expires === 'number' && Date.now() > data.expires) {
+				if (typeof data.expires === 'number' && Date.now() > data.expires) {
 					this.delete(key);
 					return undefined;
 				}
-				return store.ttlSupport ? data : data.value;
+				return data.value;
 			});
 	}
 
@@ -75,10 +75,8 @@ class Keyv extends EventEmitter {
 
 		return Promise.resolve()
 			.then(() => {
-				if (!store.ttlSupport) {
-					const expires = (typeof ttl === 'number') ? (Date.now() + ttl) : null;
-					value = { value, expires };
-				}
+				const expires = (typeof ttl === 'number') ? (Date.now() + ttl) : null;
+				value = { value, expires };
 				return store.set(key, JSONB.stringify(value), ttl);
 			})
 			.then(() => true);

--- a/test/keyv.js
+++ b/test/keyv.js
@@ -18,10 +18,9 @@ test.serial('Keyv accepts storage adapters', async t => {
 	t.is(store.size, 1);
 });
 
-test.serial('Keyv hands tll functionality over to ttl supporting stores', async t => {
-	t.plan(3);
+test.serial('Keyv passes tll info to stores', async t => {
+	t.plan(1);
 	const store = new Map();
-	store.ttlSupport = true;
 	const storeSet = store.set;
 	store.set = (key, val, ttl) => {
 		t.is(ttl, 100);
@@ -29,10 +28,6 @@ test.serial('Keyv hands tll functionality over to ttl supporting stores', async 
 	};
 	const keyv = new Keyv({ store });
 	await keyv.set('foo', 'bar', 100);
-	t.is(await keyv.get('foo'), 'bar');
-	tk.freeze(Date.now() + 150);
-	t.is(await keyv.get('foo'), 'bar');
-	tk.reset();
 });
 
 test.serial('Keyv respects default tll option', async t => {


### PR DESCRIPTION
Ensuring we have a common default data structure for all stores will allow us to easily make changes in the future while keeping backwards compatibility.

For example, we can add an option to remove the timestamp wrapper if you're using Key as a persistent store. Without changing the option the default behaviour won't change, so existing users can upgrade without any code changes. New users can enable the option and benefit from reduced storage requirements.

Normalizing all timestamp data also allows us to very easily create migration tools to automatically migrate between stores.

