### PR TITLE
Implemented exposed iterables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ test/testdb.sqlite
 #npm5
 package-lock.json
 
+#yarn
+yarn.lock
+
 # Logs
 logs
 *.log

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,10 @@ class Keyv extends EventEmitter {
 		return `${this.opts.namespace}:${key}`;
 	}
 
+	_removeKeyPrefix(key) {
+		return key.replace(`${this.opts.namespace}:`, '');
+	}
+
 	get(key) {
 		key = this._getKeyPrefix(key);
 		const store = this.opts.store;
@@ -97,6 +101,45 @@ class Keyv extends EventEmitter {
 		const store = this.opts.store;
 		return Promise.resolve()
 			.then(() => store.clear());
+	}
+
+	keys() {
+		const store = this.opts.store;
+		return Promise.resolve()
+			.then(() => store.keys())
+			.then(keys => {
+				const data = [];
+				for (const key of keys) {
+					data.push(this._removeKeyPrefix(key));
+				}
+				return data;
+			});
+	}
+
+	values() {
+		const store = this.opts.store;
+		return Promise.resolve()
+			.then(() => store.values())
+			.then(values => {
+				const data = [];
+				for (const value of values) {
+					data.push(this.opts.deserialize(value).value);
+				}
+				return data;
+			});
+	}
+
+	entries() {
+		const store = this.opts.store;
+		return Promise.resolve()
+			.then(() => store.entries())
+			.then(entries => {
+				const data = [];
+				for (const entry of entries) {
+					data.push([this._removeKeyPrefix(entry[0]), this.opts.deserialize(entry[1]).value]);
+				}
+				return data;
+			});
 	}
 }
 

--- a/test/keyv.js
+++ b/test/keyv.js
@@ -75,6 +75,30 @@ test.serial('.set(key, val, ttl) where ttl is "0" overwrites default tll option 
 	tk.reset();
 });
 
+test.serial('.keys()', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store });
+	await keyv.set('foo', 'bar');
+	await keyv.set('fizz', 'buzz');
+	t.deepEqual(await keyv.keys(), ['foo', 'fizz']);
+});
+
+test.serial('.values()', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store });
+	await keyv.set('foo', 'bar');
+	await keyv.set('fizz', 'buzz');
+	t.deepEqual(await keyv.values(), ['bar', 'buzz']);
+});
+
+test.serial('.entries()', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store });
+	await keyv.set('foo', 'bar');
+	await keyv.set('fizz', 'buzz');
+	t.deepEqual(await keyv.entries(), [['foo', 'bar'], ['fizz', 'buzz']]);
+});
+
 test.serial('Keyv uses custom serializer when provided instead of json-buffer', async t => {
 	t.plan(3);
 	const store = new Map();


### PR DESCRIPTION
Implemented exposed iterables as suggested in #40. Also added a function
_removeKeyPrefix so it's easy to remove prefix from key when returning
it in an iterable. Tests are added too for all three functions(keys,
values, entries).

Ref: https://github.com/lukechilds/keyv/issues/40