### PR TITLE
docs: consider to add @keyv/lru to the official repository list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npm install --save @keyv/mongo
 npm install --save @keyv/sqlite
 npm install --save @keyv/postgres
 npm install --save @keyv/mysql
+npm install --save @keyv/lru
 ```
 
 Create a new Keyv instance, passing your connection string if applicable. Keyv will automatically load the correct storage adapter.


### PR DESCRIPTION
I just created a project to add LRU as a store. I'd like to have official support for it. I noticed that the Keyv factory has stores hard-coded. Would you consider granting "official" status to https://github.com/e0ipso/keyv-lru?

This uses the `tiny-lru` library, which is faster than `quick-lru`.

I already integrated in the automated tests the official test suite.