### PR TITLE
Implement delete multiple keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,9 @@ class Keyv extends EventEmitter {
 	}
 
 	_getKeyPrefix(key) {
+		if (Array.isArray(key)) {
+			return key.map(key => `${this.opts.namespace}:${key}`);
+		}
 		return `${this.opts.namespace}:${key}`;
 	}
 
@@ -90,7 +93,12 @@ class Keyv extends EventEmitter {
 		key = this._getKeyPrefix(key);
 		const store = this.opts.store;
 		return Promise.resolve()
-			.then(() => store.delete(key));
+			.then(() => {
+				if (store instanceof Map && Array.isArray(key)) {
+					return Promise.all(key.map(key => store.delete(key)));
+				}
+				return store.delete(key);
+			});
 	}
 
 	clear() {

--- a/test/keyv.js
+++ b/test/keyv.js
@@ -75,6 +75,21 @@ test.serial('.set(key, val, ttl) where ttl is "0" overwrites default tll option 
 	tk.reset();
 });
 
+test.serial('.delete(key) where key is a single key', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store });
+	await keyv.set('foo', 'bar');
+	t.is(await keyv.delete('foo'), true);
+});
+
+test.serial('.delete(key) where key is array of keys', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store });
+	await keyv.set('foo', 'bar');
+	await keyv.set('fizz', 'buzz');
+	t.deepEqual(await keyv.delete(['foo', 'fizz']), [true, true]);
+});
+
 test.serial('Keyv uses custom serializer when provided instead of json-buffer', async t => {
 	t.plan(3);
 	const store = new Map();


### PR DESCRIPTION
Passing array of keys to `.delete()` function deletes multiple keys all at once.

Closes: https://github.com/lukechilds/keyv/issues/41