### PR TITLE
Add support for get() without key, returning all rows/documents in table/collection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const loadStore = opts => {
 	};
 	if (opts.adapter || opts.uri) {
 		const adapter = opts.adapter || /^[^:]*/.exec(opts.uri)[0];
-		return new(require(adapters[adapter]))(opts);
+		return new (require(adapters[adapter]))(opts);
 	}
 	return new Map();
 };
@@ -23,14 +23,13 @@ const loadStore = opts => {
 class Keyv extends EventEmitter {
 	constructor(uri, opts) {
 		super();
-		this.opts = Object.assign({
+		this.opts = Object.assign(
+			{
 				namespace: 'keyv',
 				serialize: JSONB.stringify,
 				deserialize: JSONB.parse
 			},
-			(typeof uri === 'string') ? {
-				uri
-			} : uri,
+			(typeof uri === 'string') ? { uri } : uri,
 			opts
 		);
 
@@ -102,10 +101,7 @@ class Keyv extends EventEmitter {
 		return Promise.resolve()
 			.then(() => {
 				const expires = (typeof ttl === 'number') ? (Date.now() + ttl) : null;
-				value = {
-					value,
-					expires
-				};
+				value = { value, expires };
 				return store.set(key, this.opts.serialize(value), ttl);
 			})
 			.then(() => true);

--- a/src/index.js
+++ b/src/index.js
@@ -4,125 +4,125 @@ const EventEmitter = require('events');
 const JSONB = require('json-buffer');
 
 const loadStore = opts => {
-    const adapters = {
-        redis: '@keyv/redis',
-        mongodb: '@keyv/mongo',
-        mongo: '@keyv/mongo',
-        sqlite: '@keyv/sqlite',
-        postgresql: '@keyv/postgres',
-        postgres: '@keyv/postgres',
-        mysql: '@keyv/mysql'
-    };
-    if (opts.adapter || opts.uri) {
-        const adapter = opts.adapter || /^[^:]*/.exec(opts.uri)[0];
-        return new(require(adapters[adapter]))(opts);
-    }
-    return new Map();
+	const adapters = {
+		redis: '@keyv/redis',
+		mongodb: '@keyv/mongo',
+		mongo: '@keyv/mongo',
+		sqlite: '@keyv/sqlite',
+		postgresql: '@keyv/postgres',
+		postgres: '@keyv/postgres',
+		mysql: '@keyv/mysql'
+	};
+	if (opts.adapter || opts.uri) {
+		const adapter = opts.adapter || /^[^:]*/.exec(opts.uri)[0];
+		return new(require(adapters[adapter]))(opts);
+	}
+	return new Map();
 };
 
 class Keyv extends EventEmitter {
-    constructor(uri, opts) {
-        super();
-        this.opts = Object.assign({
-                namespace: 'keyv',
-                serialize: JSONB.stringify,
-                deserialize: JSONB.parse
-            },
-            (typeof uri === 'string') ? {
-                uri
-            } : uri,
-            opts
-        );
+	constructor(uri, opts) {
+		super();
+		this.opts = Object.assign({
+				namespace: 'keyv',
+				serialize: JSONB.stringify,
+				deserialize: JSONB.parse
+			},
+			(typeof uri === 'string') ? {
+				uri
+			} : uri,
+			opts
+		);
 
-        if (!this.opts.store) {
-            const adapterOpts = Object.assign({}, this.opts);
-            this.opts.store = loadStore(adapterOpts);
-        }
+		if (!this.opts.store) {
+			const adapterOpts = Object.assign({}, this.opts);
+			this.opts.store = loadStore(adapterOpts);
+		}
 
-        if (typeof this.opts.store.on === 'function') {
-            this.opts.store.on('error', err => this.emit('error', err));
-        }
+		if (typeof this.opts.store.on === 'function') {
+			this.opts.store.on('error', err => this.emit('error', err));
+		}
 
-        this.opts.store.namespace = this.opts.namespace;
-    }
+		this.opts.store.namespace = this.opts.namespace;
+	}
 
-    _checkIsExpired(data) {
-        if (typeof data.expires === 'number' && Date.now() > data.expires) {
-            this.delete(key);
-            return true;
-        }
+	_checkIsExpired(data) {
+		if (typeof data.expires === 'number' && Date.now() > data.expires) {
+			this.delete(key);
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    _deserializeData(data) {
-        if (!data) return data;
-        if (typeof data === 'string') {
-            return this.opts.deserialize(data);
-        }
+	_deserializeData(data) {
+		if (!data) return data;
+		if (typeof data === 'string') {
+			return this.opts.deserialize(data);
+		}
 
-        if (Array.isArray(data)) {
-            return data
-                .map(row => this._deserializeData(row))
-                .map(row => this._checkIsExpired(row) ? undefined : row.value);
-        }
+		if (Array.isArray(data)) {
+			return data
+				.map(row => this._deserializeData(row))
+				.map(row => this._checkIsExpired(row) ? undefined : row.value);
+		}
 
-        return data;
-    }
+		return data;
+	}
 
-    _getKeyPrefix(key) {
-        return key ? `${this.opts.namespace}:${key}` : undefined;
-    }
+	_getKeyPrefix(key) {
+		return key ? `${this.opts.namespace}:${key}` : undefined;
+	}
 
-    get(key, opts) {
-        key = this._getKeyPrefix(key);
-        const store = this.opts.store;
-        return Promise.resolve()
-            .then(() => store.get(key))
-            .then(rawData => this._deserializeData(rawData))
-            .then(data => {
-                if (!Array.isArray(data) && this._checkIsExpired(data)) {
-                    return undefined;
-                }
+	get(key, opts) {
+		key = this._getKeyPrefix(key);
+		const store = this.opts.store;
+		return Promise.resolve()
+			.then(() => store.get(key))
+			.then(rawData => this._deserializeData(rawData))
+			.then(data => {
+				if (!Array.isArray(data) && this._checkIsExpired(data)) {
+					return undefined;
+				}
 
-                return (opts && opts.raw) ? data : (data.value || data)
-            });
-    }
+				return (opts && opts.raw) ? data : (data.value || data)
+			});
+	}
 
-    set(key, value, ttl) {
-        key = this._getKeyPrefix(key);
-        if (typeof ttl === 'undefined') {
-            ttl = this.opts.ttl;
-        }
-        if (ttl === 0) {
-            ttl = undefined;
-        }
-        const store = this.opts.store;
+	set(key, value, ttl) {
+		key = this._getKeyPrefix(key);
+		if (typeof ttl === 'undefined') {
+			ttl = this.opts.ttl;
+		}
+		if (ttl === 0) {
+			ttl = undefined;
+		}
+		const store = this.opts.store;
 
-        return Promise.resolve()
-            .then(() => {
-                const expires = (typeof ttl === 'number') ? (Date.now() + ttl) : null;
-                value = {
-                    value,
-                    expires
-                };
-                return store.set(key, this.opts.serialize(value), ttl);
-            })
-            .then(() => true);
-    }
+		return Promise.resolve()
+			.then(() => {
+				const expires = (typeof ttl === 'number') ? (Date.now() + ttl) : null;
+				value = {
+					value,
+					expires
+				};
+				return store.set(key, this.opts.serialize(value), ttl);
+			})
+			.then(() => true);
+	}
 
-    delete(key) {
-        key = this._getKeyPrefix(key);
-        const store = this.opts.store;
-        return Promise.resolve()
-            .then(() => store.delete(key));
-    }
+	delete(key) {
+		key = this._getKeyPrefix(key);
+		const store = this.opts.store;
+		return Promise.resolve()
+			.then(() => store.delete(key));
+	}
 
-    clear() {
-        const store = this.opts.store;
-        return Promise.resolve()
-            .then(() => store.clear());
-    }
+	clear() {
+		const store = this.opts.store;
+		return Promise.resolve()
+			.then(() => store.clear());
+	}
 }
 
 module.exports = Keyv;


### PR DESCRIPTION
- db.get(key) works well when a key is provided, returning a specific row in the table.
- db.get() would work wonderfully to return all rows in a table, since no key was provided.

This PR makes it possible. Minor changes to make it happen:
- Moved isExpired logic to _checkIsExpired() fn, so it can be re-used per row, if multiple rows are returned.
- Added Array handler for _deserializeData() fn.

The only part I wasn't sure about was the name-spacing, should it return all rows in a particular name-space? Or all rows across all name-spaces?