### PR TITLE
Add goto-bus-stop/keyv-firestore third party adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The following are third-party storage adapters compatible with Keyv:
 - [quick-lru](https://github.com/sindresorhus/quick-lru) - Simple "Least Recently Used" (LRU) cache
 - [keyv-file](https://github.com/zaaack/keyv-file) - File system storage adapter for Keyv
 - [keyv-dynamodb](https://www.npmjs.com/package/keyv-dynamodb) - DynamoDB storage adapter for Keyv
+- [keyv-firestore ](https://github.com/goto-bus-stop/keyv-firestore) – Firebase Cloud Firestore adapter for Keyv
 
 ## Add Cache Support to your Module
 


### PR DESCRIPTION
Hello, I used this third party for creating a [self-hosted count service](https://github.com/Kikobeats/count) and it works like a charm, very happy with the result 🙂