### PR TITLE
build: use `buffer-json` instead of `json-buffer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ await cache.get('foo'); // 'cache'
 
 ### Custom Serializers
 
-Keyv uses [`json-buffer`](https://github.com/dominictarr/json-buffer) for data serialization to ensure consistency across different backends.
+Keyv uses [`buffer-json`](https://npm.im/buffer-json) for data serialization to ensure consistency across different backends.
 
 You can optionally provide your own serialization functions to support extra data types or to serialize to something other than JSON.
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/lukechilds/keyv",
   "dependencies": {
-    "json-buffer": "3.0.1"
+    "buffer-json": "~2.0.0"
   },
   "devDependencies": {
     "ava": "^2.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const EventEmitter = require('events');
-const JSONB = require('json-buffer');
+const JSONB = require('buffer-json');
 
 const loadStore = opts => {
 	const adapters = {

--- a/test/keyv.js
+++ b/test/keyv.js
@@ -86,7 +86,7 @@ test.serial('.get(key, {raw: true}) returns the raw object instead of the value'
 	t.is(rawObject.value, 'bar');
 });
 
-test.serial('Keyv uses custom serializer when provided instead of json-buffer', async t => {
+test.serial('Keyv uses custom serializer when provided instead of buffer-json', async t => {
 	t.plan(3);
 	const store = new Map();
 	const serialize = data => {


### PR DESCRIPTION
I noted `json-buffer` is an archived project, I replaced it for a `buffer-json`, it's basically the same but up to date and maintained.