### PR TITLE
build: add `handleErrors` for more granular error control

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ A custom deserialization function.
 Type: `Boolean`<br>
 Default: `true`
 
-When it's `true`, errors on `options.store` will not be emitted at keyv level.
+When it's `true`, errors on `options.store` will be emitted at keyv level.
 
 #### options.store
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ Default: `JSONB.parse`
 
 A custom deserialization function.
 
+#### options.handleErrors
+
+Type: `Boolean`<br>
+Default: `true`
+
+When it's `true`, errors on `options.store` will not be emitted at keyv level.
+
 #### options.store
 
 Type: `Storage adapter instance`<br>

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ class Keyv extends EventEmitter {
 		}
 
 		if (typeof this.opts.store.on === 'function' && !this.opts.store.errorAlreadyHandled) {
-			this.opts.store.errorAlreadyHandled = true
+			this.opts.store.errorAlreadyHandled = true;
 			this.opts.store.once('error', err => this.emit('error', err));
 		}
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,8 @@ class Keyv extends EventEmitter {
 			{
 				namespace: 'keyv',
 				serialize: JSONB.stringify,
-				deserialize: JSONB.parse
+				deserialize: JSONB.parse,
+				handleErrors: true
 			},
 			(typeof uri === 'string') ? { uri } : uri,
 			opts
@@ -39,8 +40,7 @@ class Keyv extends EventEmitter {
 			this.opts.store = loadStore(adapterOpts);
 		}
 
-		if (typeof this.opts.store.on === 'function' && !this.opts.store.errorAlreadyHandled) {
-			this.opts.store.errorAlreadyHandled = true;
+		if (this.opts.handleErrors && typeof this.opts.store.on === 'function') {
 			this.opts.store.on('error', err => this.emit('error', err));
 		}
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ class Keyv extends EventEmitter {
 
 		if (typeof this.opts.store.on === 'function' && !this.opts.store.errorAlreadyHandled) {
 			this.opts.store.errorAlreadyHandled = true;
-			this.opts.store.once('error', err => this.emit('error', err));
+			this.opts.store.on('error', err => this.emit('error', err));
 		}
 
 		this.opts.store.namespace = this.opts.namespace;

--- a/src/index.js
+++ b/src/index.js
@@ -39,9 +39,9 @@ class Keyv extends EventEmitter {
 			this.opts.store = loadStore(adapterOpts);
 		}
 
-		if (typeof this.opts.store.once === 'function' && !this.opts.store.errorAlreadyHandled) {
+		if (typeof this.opts.store.on === 'function' && !this.opts.store.errorAlreadyHandled) {
 			this.opts.store.errorAlreadyHandled = true;
-			this.opts.store.once('error', err => this.emit('error', err));
+			this.opts.store.on('error', err => this.emit('error', err));
 		}
 
 		this.opts.store.namespace = this.opts.namespace;

--- a/src/index.js
+++ b/src/index.js
@@ -39,9 +39,9 @@ class Keyv extends EventEmitter {
 			this.opts.store = loadStore(adapterOpts);
 		}
 
-		if (typeof this.opts.store.on === 'function' && !this.opts.store.errorAlreadyHandled) {
+		if (typeof this.opts.store.once === 'function' && !this.opts.store.errorAlreadyHandled) {
 			this.opts.store.errorAlreadyHandled = true;
-			this.opts.store.on('error', err => this.emit('error', err));
+			this.opts.store.once('error', err => this.emit('error', err));
 		}
 
 		this.opts.store.namespace = this.opts.namespace;

--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,9 @@ class Keyv extends EventEmitter {
 			this.opts.store = loadStore(adapterOpts);
 		}
 
-		if (typeof this.opts.store.on === 'function') {
-			this.opts.store.on('error', err => this.emit('error', err));
+		if (typeof this.opts.store.on === 'function' && !this.opts.store.errorAlreadyHandled) {
+			this.opts.store.errorAlreadyHandled = true
+			this.opts.store.once('error', err => this.emit('error', err));
 		}
 
 		this.opts.store.namespace = this.opts.namespace;


### PR DESCRIPTION
closes #101

> This line of code is attaching an event listener to a store passed as `store` option: https://github.com/lukechilds/keyv/blob/b87be6c60dd7ccf9efe8be3875c32c5b120fd7ff/src/index.js#L43
> 
> The thing is, a store can be shared between different keyv instances (the most common pattern there is reusing a Redis instance with difference namespace every time) so in that way the event listener is being added every time a keyv instance is created.
> 
> 