### PR TITLE
Fix double prefix with TTL

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,10 +51,10 @@ class Keyv extends EventEmitter {
 	}
 
 	get(key, opts) {
-		key = this._getKeyPrefix(key);
+		const keyPrefixed = this._getKeyPrefix(key);
 		const { store } = this.opts;
 		return Promise.resolve()
-			.then(() => store.get(key))
+			.then(() => store.get(keyPrefixed))
 			.then(data => {
 				return (typeof data === 'string') ? this.opts.deserialize(data) : data;
 			})

--- a/test/keyv.js
+++ b/test/keyv.js
@@ -38,6 +38,7 @@ test.serial('Keyv respects default tll option', async t => {
 	t.is(await keyv.get('foo'), 'bar');
 	tk.freeze(Date.now() + 150);
 	t.is(await keyv.get('foo'), undefined);
+	t.is(store.size, 0);
 	tk.reset();
 });
 


### PR DESCRIPTION
Entries set with a TTL are not deleted, the `delete` call is made with a double prefix which does not delete the entry.

Corresponding issue: https://github.com/lukechilds/keyv/issues/108