### PR TITLE
Remove dynamic require

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,17 +5,17 @@ const JSONB = require('json-buffer');
 
 const loadStore = opts => {
 	const adapters = {
-		redis: '@keyv/redis',
-		mongodb: '@keyv/mongo',
-		mongo: '@keyv/mongo',
-		sqlite: '@keyv/sqlite',
-		postgresql: '@keyv/postgres',
-		postgres: '@keyv/postgres',
-		mysql: '@keyv/mysql'
+		redis: () => require('@keyv/redis'),
+		mongodb: () => require('@keyv/mongo'),
+		mongo: () => require('@keyv/mongo'),
+		sqlite: () => require('@keyv/sqlite'),
+		postgresql: () => require('@keyv/postgres'),
+		postgres: () => require('@keyv/postgres'),
+		mysql: () => require('@keyv/mysql')
 	};
 	if (opts.adapter || opts.uri) {
 		const adapter = opts.adapter || /^[^:]*/.exec(opts.uri)[0];
-		return new (require(adapters[adapter]))(opts);
+		return new adapters[adapter]()(opts);
 	}
 
 	return new Map();

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const loadStore = opts => {
 	};
 	if (opts.adapter || opts.uri) {
 		const adapter = opts.adapter || /^[^:]*/.exec(opts.uri)[0];
-		return new adapters[adapter]()(opts);
+		return new (adapters[adapter]())(opts);
 	}
 
 	return new Map();


### PR DESCRIPTION
I'm using this module (through npm.im/got) for a serverless function and I'm getting this warning:

```
3:31:45 PM: WARNING in ../node_modules/keyv/src/index.js 18:14-40
3:31:45 PM: Critical dependency: the request of a dependency is an expression
3:31:45 PM:  @ ../node_modules/cacheable-request/src/index.js
3:31:45 PM:  @ ../node_modules/got/dist/source/core/index.js
3:31:45 PM:  @ ../node_modules/got/dist/source/create.js
3:31:45 PM:  @ ../node_modules/got/dist/source/index.js
3:31:45 PM:  @ ./api.js
```

It's not technically a problem, but it is an annoyance and I'd love to avoid the warning.

This simply removes the dynamic require for static and lazy requires. Just a refactor. No functionality change here.