### PR TITLE
feature: allow empty namespace

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ class Keyv extends EventEmitter {
 	}
 
 	_getKeyPrefix(key) {
-		return `${this.opts.namespace}:${key}`;
+		return this.opts.namespace ? `${this.opts.namespace}:${key}` : key;
 	}
 
 	get(key, opts) {

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ class Keyv extends EventEmitter {
 	}
 
 	_getKeyPrefix(key) {
-		return this.opts.namespace ? `${this.opts.namespace}:${key}` : key;
+		return this.opts.namespace ? `${this.opts.namespace}:${key}` : String(key);
 	}
 
 	get(key, opts) {

--- a/test/keyv.js
+++ b/test/keyv.js
@@ -124,5 +124,26 @@ test.serial('Keyv supports async serializer/deserializer', async t => {
 	t.is(await keyv.get('foo'), 'bar');
 });
 
+test.serial('Keyv uses a default namespace', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store });
+	await keyv.set('foo', 'bar');
+	t.is([...store.keys()][0], 'keyv:foo');
+});
+
+test.serial('Default namespace can be overridden', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store, namespace: 'magic' });
+	await keyv.set('foo', 'bar');
+	t.is([...store.keys()][0], 'magic:foo');
+});
+
+test.serial('An empty namespace stores the key as-is', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store, namespace: '' });
+	await keyv.set(42, 'foo');
+	t.is([...store.keys()][0], 42);
+});
+
 const store = () => new Map();
 keyvTestSuite(test, Keyv, store);

--- a/test/keyv.js
+++ b/test/keyv.js
@@ -128,21 +128,40 @@ test.serial('Keyv uses a default namespace', async t => {
 	const store = new Map();
 	const keyv = new Keyv({ store });
 	await keyv.set('foo', 'bar');
+	const savedValue = await keyv.get('foo');
+
 	t.is([...store.keys()][0], 'keyv:foo');
+	t.is(savedValue, 'bar');
 });
 
 test.serial('Default namespace can be overridden', async t => {
 	const store = new Map();
 	const keyv = new Keyv({ store, namespace: 'magic' });
 	await keyv.set('foo', 'bar');
+	const savedValue = await keyv.get('foo');
+
 	t.is([...store.keys()][0], 'magic:foo');
+	t.is(savedValue, 'bar');
 });
 
-test.serial('An empty namespace stores the key as-is', async t => {
+test.serial('An empty namespace can be used', async t => {
 	const store = new Map();
 	const keyv = new Keyv({ store, namespace: '' });
-	await keyv.set(42, 'foo');
-	t.is([...store.keys()][0], 42);
+	await keyv.set(42, 'bar');
+	const savedValue = await keyv.get('42');
+
+	t.is([...store.keys()][0], '42');
+	t.is(savedValue, 'bar');
+});
+
+test.serial('A null namespace can be used', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store, namespace: null });
+	await keyv.set(42, 'bar');
+	const savedValue = await keyv.get('42');
+
+	t.is([...store.keys()][0], '42');
+	t.is(savedValue, 'bar');
 });
 
 const store = () => new Map();


### PR DESCRIPTION
### Why? 
* Basically I copy-pasted the code from this PR: https://github.com/lukechilds/keyv/pull/48, since it was stale for many months (thanks  @mjesun  for the original code and test)
* Also added the requested tests.
* Feature was also requested in this other PR https://github.com/lukechilds/keyv/issues/72

The main value of this change is that, when using most other adapters (sqlite, mysql, mongo, pgsql), its much cleaner to just store things in different tables/collections instead of using namespaces.

For example:
```js
const cache = new Keyv('mongodb://user:pass@localhost:27017/dbname', { collection: 'cache', namespace: null });
const users = new Keyv('mongodb://user:pass@localhost:27017/dbname', { collection: 'users', namespace: null });
```
or
```js
const keyv = new Keyv('sqlite://path/to/database.sqlite', { table: 'cache', namespace: null });
const users = new Keyv('sqlite://path/to/database.sqlite', { table: 'users' namespace: null });
```
The stored key remains pure, and helps with readability, and of course this is optional.

And huge thanks for the great project @lukechilds :D 