### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The following are third-party storage adapters compatible with Keyv:
 - [keyv-firestore ](https://github.com/goto-bus-stop/keyv-firestore) – Firebase Cloud Firestore adapter for Keyv
 - [keyv-mssql](https://github.com/pmorgan3/keyv-mssql) - Microsoft Sql Server adapter for Keyv
 - [keyv-memcache](https://github.com/jaredwray/keyv-memcache) - Memcache storage adapter for Keyv
+- [keyv-anyredis](https://github.com/natesilva/keyv-anyredis) - Support for Redis clusters and alternative Redis clients
 
 ## Add Cache Support to your Module
 


### PR DESCRIPTION
Add keyv-anyredis to the third-party storage adapters list. This client supports other Redis clients besides ioredis, and it also supports cluster mode for those clients that can use it (including ioredis).